### PR TITLE
Pointing google-cloud-spanner to 6.97

### DIFF
--- a/spanner-data-validator-java/pom.xml
+++ b/spanner-data-validator-java/pom.xml
@@ -27,6 +27,7 @@
 
   <properties>
     <beam.version>2.62.0</beam.version>
+    <google-cloud-spanner.version>6.97.0</google-cloud-spanner.version>
 
     <maven.compiler.target>1.11</maven.compiler.target>
     <maven.compiler.source>1.11</maven.compiler.source>
@@ -219,6 +220,12 @@
           <artifactId>beam-runners-direct-java</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+          <exclusion>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-spanner</artifactId>
+          </exclusion>
+        </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -235,6 +242,17 @@
           <artifactId>beam-runners-portability-java</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+        <dependency>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+          <version>6.97.0</version>
         </dependency>
       </dependencies>
     </profile>
@@ -248,6 +266,12 @@
           <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -261,12 +285,24 @@
           <artifactId>beam-runners-direct-java</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -283,6 +319,12 @@
           <artifactId>${flink.artifact.name}</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -301,6 +343,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>jul-to-slf4j</artifactId>
             </exclusion>
+              <exclusion>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-spanner</artifactId>
+              </exclusion>
           </exclusions>
         </dependency>
         <dependency>
@@ -308,6 +354,12 @@
           <artifactId>beam-sdks-java-io-hadoop-file-system</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>
@@ -319,6 +371,10 @@
               <groupId>org.slf4j</groupId>
               <artifactId>jul-to-slf4j</artifactId>
             </exclusion>
+              <exclusion>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-spanner</artifactId>
+              </exclusion>
           </exclusions>
         </dependency>
         <dependency>
@@ -337,6 +393,12 @@
           <artifactId>beam-runners-samza</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -348,6 +410,12 @@
           <artifactId>beam-runners-twister2</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -372,7 +440,11 @@
               <groupId>org.slf4j</groupId>
               <artifactId>slf4j-log4j12</artifactId>
             </exclusion>
-          </exclusions>
+              <exclusion>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-spanner</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -385,6 +457,12 @@
           <artifactId>beam-runners-jet</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>com.google.cloud</groupId>
+              <artifactId>google-cloud-spanner</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
     </profile>
@@ -397,6 +475,12 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-core</artifactId>
       <version>${beam.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Adds a dependency on the Beam Google Cloud Platform IO module. -->
@@ -404,6 +488,12 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
       <version>${beam.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -420,6 +510,10 @@
           <groupId>com.google.cloud.bigtable</groupId>
           <artifactId>bigtable-client-core</artifactId>
         </exclusion>
+          <exclusion>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-spanner</artifactId>
+          </exclusion>
       </exclusions>
     </dependency>
 
@@ -446,14 +540,14 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-python</artifactId>
       <version>${beam.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
-    <!-- Adds a dependency on the Beam Kafka IO module. -->
-    <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-sdks-java-io-kafka</artifactId>
-      <version>${beam.version}</version>
-    </dependency>
 
     <!-- Adds a dependency on the Postgres JDBC module. -->
     <dependency>
@@ -474,6 +568,12 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-io-jdbc</artifactId>
       <version>${beam.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Spanner -->
@@ -639,6 +739,12 @@
         <groupId>com.google.cloud.teleport.v2</groupId>
         <artifactId>spanner-migrations-sdk</artifactId>
         <version>1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.cloud</groupId>
+          <artifactId>google-cloud-spanner</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 
@@ -656,6 +762,11 @@
         <version>${libraries-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>google-cloud-spanner</artifactId>
+        <version>6.97.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
To Compile this, please clean your `.m2`
For example
```
 rm -rf ~/.m2/repository/com/google/cloud/google-cloud-spanner/
 rm -rf target/
```
Proceed with the usual build and use the bundled jar.
